### PR TITLE
feat: 付費文章頁面隨是否已閱讀過狀態改變內容

### DIFF
--- a/components/articles/ArticleComment.vue
+++ b/components/articles/ArticleComment.vue
@@ -14,6 +14,14 @@ const props = defineProps({
     type: Array as () => Comment[],
     required: true
   },
+  articleId: {
+    type: String,
+    required: true
+  },
+  userId: {
+    type: String,
+    required: true
+  },
   getArticleDetail: {
     type: Function,
     required: true
@@ -70,7 +78,7 @@ const updateComment = async (id: number) => {
     if (res.StatusCode === 200) {
       alert(res.Message)
       editingId.value = null
-      props.getArticleDetail()
+      props.getArticleDetail(props.articleId, props.userId)
     }
   } catch (error: any) {
     console.log(error.response)
@@ -94,7 +102,7 @@ const delComment = async (id: number) => {
     console.log(res)
     if (res.StatusCode === 200) {
       alert(res.Message)
-      props.getArticleDetail()
+      props.getArticleDetail(props.articleId, props.userId)
     }
   } catch (error: any) {
     console.log(error.response)

--- a/components/home/LatestArticleCard.vue
+++ b/components/home/LatestArticleCard.vue
@@ -1,60 +1,35 @@
-<script setup>
-const data = [
-  {
-    id: 1,
-    Classification: '個人成長',
-    date: '2023.6.31',
-    title: '重拾自我價值：探索內在的力量',
-    content:
-      '在這個忙碌、要求和競爭的世界中，我們常常忽略了最重要的一個人──自己。愛自己並不是自私或自戀，而是一種對自己的尊重和關懷。當我們學會愛自己時，我們能夠建立健康的自尊心、提高生活質量',
-    imgUrl: 'https://picsum.photos/392/247'
-  },
-  {
-    id: 2,
-    Classification: '情緒察覺',
-    date: '2023.6.30',
-    title: '認識自我與擁抱內在小孩的旅程',
-    content:
-      '人生是一個不斷成長和發展的旅程，而認識自我是這個旅程中至關重要的一部分。我們每個人都有一個內在的小孩，那個純真、好奇和無憂無慮的自己。',
-    imgUrl: 'https://picsum.photos/392/247'
-  },
-  {
-    id: 3,
-    Classification: '親密關係',
-    date: '2023.6.30',
-    title: '別離與成長：好好道別的力量',
-    content:
-      '在人生的旅程中，我們常常面對各種離別和告別。不論是和摯愛的人分手、離開一個熟悉的環境，或是告別已逝的親友，說再見總是一個不可避免的過程。然而，我們可以選擇以一種全新的角度來看待這些告別，並學會好好說再見。',
-    imgUrl: 'https://picsum.photos/392/247'
-  },
-  {
-    id: 4,
-    Classification: '個人成長',
-    date: '2023.6.20',
-    title: '獨處的力量：發現內在寧靜與成長的時刻',
-    content:
-      '在人生的旅程中，我們常常面對各種離別和告別。不論是和摯愛的人分手、離開一個熟悉的環境，或是告別已逝的親友，說再見總是一個不可避免的過程。然而，我們可以選擇以一種全新的角度來看待這些告別，並學會好好說再見。',
-    imgUrl: 'https://picsum.photos/392/247'
-  },
-  {
-    id: 5,
-    Classification: '親密關係',
-    date: '2023.5.30',
-    title: '擺脫不健康的家庭關係，重塑心理平衡的五個關鍵方法',
-    content:
-      '家庭關係對我們的心理健康和幸福感有著深遠的影響。然而，有時候我們可能陷入不健康的家庭關係中，這可能帶來壓力、焦慮和情緒困擾。',
-    imgUrl: 'https://picsum.photos/392/247'
-  },
-  {
-    id: 6,
-    Classification: '日常練習',
-    date: '2023.6.19',
-    title: '照顧身心的力量：分享三個簡單的實踐方法',
-    content:
-      '在現代快節奏的生活中，照顧好我們的身心健康變得至關重要。無論是面對工作壓力、人際關係或其他挑戰，學會照顧自己的身心可以幫助我們保持平衡、增強抵抗力，並享受更充實的生活。',
-    imgUrl: 'https://picsum.photos/392/247'
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { useUserStore } from '~/stores/user'
+
+const { userData } = storeToRefs(useUserStore())
+const runtimeConfig = useRuntimeConfig()
+const apiBase = runtimeConfig.public.apiBase
+const articles = ref<ArticleCard[]>([])
+const { formatDate } = useDateFormat()
+
+const getAllArticles = async (page = '1') => {
+  const { data, error } = await useFetch<ApiResponse>(`${apiBase}/readallarticles`, {
+    key: 'getAllArticles',
+    headers: {
+      'Content-type': 'application/json'
+    },
+    method: 'POST',
+    body: {
+      Page: page,
+      UserId: userData.value.id || '0'
+    }
+  })
+  console.log(data.value)
+
+  if (data.value!.StatusCode === 200) {
+    articles.value = data.value!.LatestArticleData
   }
-]
+  if (error.value) {
+    console.log(error.value)
+  }
+}
+onMounted(getAllArticles)
 </script>
 <template>
   <section class="container mb-6">
@@ -67,27 +42,31 @@ const data = [
     </div>
     <ul class="mb-3 grid-cols-12 gap-4 md:grid">
       <li
-        v-for="item in data"
-        :key="item.id"
+        v-for="article in articles"
+        :key="article.Id"
         class="mb-3 flex h-auto grow flex-col p-4 md:col-span-6 lg:col-span-4"
       >
         <div class="flex w-full justify-between">
           <div class="flex flex-col">
             <div class="mb-1 flex">
-              <h3 class="font-serif-tc font-semibold text-primary">{{ item.Classification }}</h3>
+              <h3 class="font-serif-tc font-semibold text-primary">{{ article.Category }}</h3>
             </div>
             <p class="mb-3 font-serif-tc text-sm font-light text-[#828282] sm:text-primary-dark">
-              {{ item.date }}
+              {{ formatDate(article.Initdate) }}
             </p>
           </div>
         </div>
-        <NuxtLink :to="`article/${item.id}`">
+        <NuxtLink :to="`article/${article.Id}`">
           <div class="flex flex-col">
             <div class="mb-3 h-[267px] max-w-full">
-              <img :src="item.imgUrl" alt="article-cover" class="h-full w-full" />
+              <img
+                :src="article.ArticleImgUrl"
+                alt="article-cover"
+                class="h-full w-full object-cover"
+              />
             </div>
-            <h4 class="mb-3 font-serif-tc text-xl font-bold text-primary">{{ item.title }}</h4>
-            <p class="flex-grow font-light text-primary-dark">{{ item.content }}</p>
+            <h4 class="mb-3 font-serif-tc text-xl font-bold text-primary">{{ article.Title }}</h4>
+            <p class="flex-grow font-light text-primary-dark">{{ article.Summary }}</p>
           </div>
         </NuxtLink>
       </li>

--- a/components/modals/CancelPlan.vue
+++ b/components/modals/CancelPlan.vue
@@ -3,6 +3,7 @@ const runtimeConfig = useRuntimeConfig()
 const apiBase = runtimeConfig.public.apiBase
 const userToken = useCookie('token')
 
+// 取消續訂
 const unsubscribe = async () => {
   if (!userToken.value) {
     return

--- a/components/writerInfo/WriterCard.vue
+++ b/components/writerInfo/WriterCard.vue
@@ -5,13 +5,21 @@ import { useUserStore } from '~/stores/user'
 const { userData } = storeToRefs(useUserStore())
 
 defineProps({
+  writerId: {
+    type: String,
+    required: true
+  },
+  userId: {
+    type: String,
+    required: true
+  },
   writerInfo: {
     type: Object as () => WriterInfo,
     default: () => {},
     required: true
   },
   getWriterInfo: {
-    type: Function as unknown as () => () => Promise<void>,
+    type: Function as unknown as () => (articleId: string, userId: string) => Promise<void>,
     required: true
   }
 })
@@ -47,7 +55,7 @@ const { followWriter, unFollowWriter } = useWriterActions()
     <button
       v-if="!writerInfo.Follow && writerInfo.Id !== userData.id"
       class="mb-16 flex w-full items-center justify-center gap-2 rounded-md bg-secondary px-3 py-2 text-white hover:bg-btn-hover active:bg-btn-active disabled:bg-btn-disabled disabled:text-white"
-      @click="followWriter(writerInfo.Id, getWriterInfo)"
+      @click="followWriter(writerInfo.Id, writerId, userId, getWriterInfo)"
     >
       <Icon name="ic:round-plus" size="24" />
       <span>追蹤</span>
@@ -55,7 +63,7 @@ const { followWriter, unFollowWriter } = useWriterActions()
     <button
       v-else-if="writerInfo.Follow && writerInfo.Id !== userData.id"
       class="mb-16 flex w-full items-center justify-center gap-2 rounded-md bg-secondary px-3 py-2 text-white hover:bg-btn-hover active:bg-btn-active disabled:bg-btn-disabled disabled:text-white"
-      @click="unFollowWriter(writerInfo.Id, getWriterInfo)"
+      @click="unFollowWriter(writerInfo.Id, writerId, userId, getWriterInfo)"
     >
       <Icon name="material-symbols:fitbit-check-small" size="24" />
       <span>追蹤中</span>

--- a/composables/useArticleActions.ts
+++ b/composables/useArticleActions.ts
@@ -4,7 +4,12 @@ export const useArticleActions = () => {
   const userToken = useCookie('token')
 
   // 收藏文章
-  const AddToCollection = async (id: number, getArticleDetail: () => Promise<void>) => {
+  const AddToCollection = async (
+    id: number,
+    articleId: string,
+    userId: string,
+    getArticleDetail: (articleId: string, userId: string) => Promise<void>
+  ) => {
     if (userToken.value) {
       try {
         const res: ApiResponse = await $fetch(`${apiBase}/article/collect/${id}`, {
@@ -17,7 +22,7 @@ export const useArticleActions = () => {
         console.log(res)
         if (res.StatusCode === 200) {
           alert(res.Message)
-          getArticleDetail()
+          getArticleDetail(articleId, userId)
         }
       } catch (error: any) {
         console.log(error.response)
@@ -26,7 +31,12 @@ export const useArticleActions = () => {
   }
 
   // 取消收藏文章
-  const cancelCollection = async (id: number, getArticleDetail: () => Promise<void>) => {
+  const cancelCollection = async (
+    id: number,
+    articleId: string,
+    userId: string,
+    getArticleDetail: (articleId: string, userId: string) => Promise<void>
+  ) => {
     if (userToken.value) {
       try {
         const res: ApiResponse = await $fetch(`${apiBase}/article/cancelcollect/${id}`, {
@@ -39,7 +49,7 @@ export const useArticleActions = () => {
         console.log(res)
         if (res.StatusCode === 200) {
           alert(res.Message)
-          getArticleDetail()
+          await getArticleDetail(articleId, userId)
         }
       } catch (error: any) {
         console.log(error.response)
@@ -48,7 +58,12 @@ export const useArticleActions = () => {
   }
 
   // 給文章愛心
-  const likeArticle = async (id: number, getArticleDetail: () => Promise<void>) => {
+  const likeArticle = async (
+    id: number,
+    articleId: string,
+    userId: string,
+    getArticleDetail: (articleId: string, userId: string) => Promise<void>
+  ) => {
     if (userToken.value) {
       try {
         const res: ApiResponse = await $fetch(`${apiBase}/article/like/${id}`, {
@@ -61,7 +76,7 @@ export const useArticleActions = () => {
         console.log(res)
         if (res.StatusCode === 200) {
           alert(res.Message)
-          getArticleDetail()
+          getArticleDetail(articleId, userId)
         }
       } catch (error: any) {
         console.log(error.response)
@@ -70,7 +85,12 @@ export const useArticleActions = () => {
   }
 
   // 取消文章愛心
-  const unlikeArticle = async (id: number, getArticleDetail: () => Promise<void>) => {
+  const unlikeArticle = async (
+    id: number,
+    articleId: string,
+    userId: string,
+    getArticleDetail: (articleId: string, userId: string) => Promise<void>
+  ) => {
     if (userToken.value) {
       try {
         const res: ApiResponse = await $fetch(`${apiBase}/article/cancellike/${id}`, {
@@ -83,7 +103,7 @@ export const useArticleActions = () => {
         console.log(res)
         if (res.StatusCode === 200) {
           alert(res.Message)
-          getArticleDetail()
+          getArticleDetail(articleId, userId)
         }
       } catch (error: any) {
         console.log(error.response)

--- a/composables/useArticleDetail.ts
+++ b/composables/useArticleDetail.ts
@@ -1,0 +1,50 @@
+// 取得單篇文章資訊
+export const useArticleDetail = () => {
+  const runtimeConfig = useRuntimeConfig()
+  const apiBase = runtimeConfig.public.apiBase
+  const articleDetail = ref<ArticleDetail | null>(null)
+  const writerInfo = ref<DetailWriter | null>(null)
+  const isCollecting = ref(false)
+  const isLiking = ref(false)
+  const isRead = ref(false)
+  const comments = ref<Comment[]>([])
+  const haveCover = ref(false)
+  const isLock = ref(true)
+
+  const getArticleDetail = async (articleId: string, userId: string) => {
+    const { data, error } = await useFetch<ApiResponse>(
+      `${apiBase}/readarticle/${articleId}/${userId}`
+    )
+    console.log(data.value)
+    if (data.value?.StatusCode === 200) {
+      articleDetail.value = data.value.ArticleData
+      writerInfo.value = data.value.WriterData
+      isCollecting.value = data.value.Collect
+      isLiking.value = data.value.Like
+      comments.value = data.value.Comment
+      isLock.value = data.value.ArticleData.Pay
+      isRead.value = data.value.ArticleData.IsRead
+      if (data.value.ArticleData.IsRead) {
+        isLock.value = false
+      }
+      if (data.value.ArticleData.ImgUrl !== '') {
+        haveCover.value = true
+      }
+    }
+
+    if (error.value) {
+      console.log(error.value)
+    }
+  }
+  return {
+    articleDetail,
+    writerInfo,
+    isCollecting,
+    isLiking,
+    comments,
+    haveCover,
+    isLock,
+    isRead,
+    getArticleDetail
+  }
+}

--- a/composables/useWriterActions.ts
+++ b/composables/useWriterActions.ts
@@ -1,9 +1,18 @@
+// 追蹤/取消追蹤作家
 export const useWriterActions = () => {
   const runtimeConfig = useRuntimeConfig()
   const apiBase = runtimeConfig.public.apiBase
   const userToken = useCookie('token')
 
-  const followWriter = async (id: number, refresh: () => Promise<void>) => {
+  // SecondId 在重新取得文章時，帶入文章ID
+  // SecondId 在重新取得作家資訊時，帶入作家ID
+
+  const followWriter = async (
+    id: number,
+    secondId: string,
+    userId: string,
+    refresh: (secondId: string, userId: string) => Promise<void>
+  ) => {
     if (!userToken.value) {
       alert('請先登入')
       return
@@ -19,14 +28,19 @@ export const useWriterActions = () => {
       console.log(res)
       if (res.StatusCode === 200) {
         alert(res.Message)
-        refresh()
+        refresh(secondId, userId)
       }
     } catch (error: any) {
       console.log(error.response)
     }
   }
 
-  const unFollowWriter = async (id: number, refresh: () => Promise<void>) => {
+  const unFollowWriter = async (
+    id: number,
+    secondId: string,
+    userId: string,
+    refresh: (secondId: string, userId: string) => Promise<void>
+  ) => {
     if (!userToken.value) {
       alert('請先登入')
       return
@@ -42,7 +56,7 @@ export const useWriterActions = () => {
       console.log(res)
       if (res.StatusCode === 200) {
         alert(res.Message)
-        refresh()
+        refresh(secondId, userId)
       }
     } catch (error: any) {
       console.log(error.response)

--- a/pages/article/index.vue
+++ b/pages/article/index.vue
@@ -120,6 +120,7 @@ const getAllArticles = async (page = '1') => {
   changeNowPage(page)
   scrollTop()
   const { data, error } = await useFetch<ApiResponse>(`${apiBase}/readallarticles`, {
+    key: 'getAllArticles',
     headers: {
       'Content-type': 'application/json'
     },

--- a/pages/writer/[id].vue
+++ b/pages/writer/[id].vue
@@ -10,11 +10,12 @@ const apiBase = runtimeConfig.public.apiBase
 const route = useRoute()
 const writerInfo = ref<WriterInfo | null>(null)
 const writerWorks = ref<WriterWork[]>([])
+const userId = isLogin.value ? String(userData.value.id) : '0'
+const writerId = route.params.id as string
 
-const getWriterInfo = async () => {
-  const userId = isLogin.value ? userData.value.id : '0'
+const getWriterInfo = async (writerId: string, userId: string) => {
   try {
-    const res: ApiResponse = await $fetch(`${apiBase}/writerarticles/${route.params.id}/${userId}`)
+    const res: ApiResponse = await $fetch(`${apiBase}/writerarticles/${writerId}/${userId}`)
     console.log(res)
     if (res.StatusCode === 200) {
       writerInfo.value = res.WriterData
@@ -25,14 +26,21 @@ const getWriterInfo = async () => {
   }
 }
 
-onMounted(getWriterInfo)
+onMounted(() => {
+  getWriterInfo(writerId, userId)
+})
 </script>
 
 <template>
   <main class="bg-sand-100 pb-40">
     <section v-if="writerInfo" class="container grid-cols-12 gap-6 pb-[188px] pt-[60px] lg:grid">
       <div class="lg:col-span-4">
-        <WriterCard :writer-info="writerInfo" :get-writer-info="getWriterInfo" />
+        <WriterCard
+          :writer-info="writerInfo"
+          :get-writer-info="getWriterInfo"
+          :user-id="userId"
+          :writer-id="writerId"
+        />
       </div>
       <div class="lg:col-span-8">
         <WriterWorkCard :writer-works="writerWorks" />

--- a/types/index.ts
+++ b/types/index.ts
@@ -62,6 +62,16 @@ declare global {
     Tags: string[]
     Category: string
     Summary: string
+    IsRead: boolean
+  }
+
+  // 文章內作者資訊
+  interface DetailWriter {
+    Id: number
+    Bio: string
+    ImgUrl: string
+    NickName: string
+    Follow: boolean
   }
 
   // 文章摘要
@@ -87,6 +97,8 @@ declare global {
     UserCollect: boolean
     UserLike: boolean
     WriterNickName: string
+    Category: string
+    Summary: string
   }
 
   // 文章留言


### PR DESCRIPTION
1. 付費文章頁面調整，文章解鎖後，不會再顯示繼續閱讀按鈕
2. 重構取得單篇文章資訊API資料，寫成composable
3. 首頁最新文章區塊改成串接API取資料